### PR TITLE
Updates php.sh to fix new repo php7.0 location

### DIFF
--- a/scripts/php.sh
+++ b/scripts/php.sh
@@ -29,7 +29,7 @@ if [[ $HHVM == "true" ]]; then
 
     sudo service hhvm restart
 else
-    sudo add-apt-repository -y ppa:ondrej/php-7.0
+    sudo add-apt-repository -y ppa:ondrej/php
     sudo apt-key update
     sudo apt-get update
     


### PR DESCRIPTION
The ppa:ondrej/php-7.0 has been changed to ppa:ondrej/php and the former will now fail provisioning.  Thanks!
